### PR TITLE
개조 인형 스탯 계산식 수정

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -303,7 +303,7 @@ namespace GFBattleTester_v2
 
                 foreach (var keys in growStats.Properties())
                 {
-                    newStats[keys.Name] = Math.Ceiling(Convert.ToDecimal(newStats[keys.Name]) + (Convert.ToDecimal(growStats[keys.Name][1]) + (Convert.ToDecimal(level - 1) * Convert.ToDecimal(growStats[keys.Name][0])) * Convert.ToDecimal(attribute[type][keys.Name]) * Convert.ToDecimal(stats[keys.Name]) * Convert.ToDecimal(growratio) / 100 / 100));
+                    newStats[keys.Name] = Math.Ceiling(Convert.ToDecimal(newStats[keys.Name]) + (Convert.ToDecimal(growStats[keys.Name][1]) + Convert.ToDecimal(level - 1) * Convert.ToDecimal(growStats[keys.Name][0])) * Convert.ToDecimal(attribute[type][keys.Name]) * Convert.ToDecimal(stats[keys.Name]) * Convert.ToDecimal(growratio) / 100 / 100);
                     //newStat[key] += math.ceil(growStats[key][1] + ((self.level - 1) * growStats[key][0]) * attribute[self.type][key] * stats[key] * growRatio / 100 / 100)
 
                 }


### PR DESCRIPTION
newStats[keys.Name] = Convert.ToDecimal(newStats[keys.Name]) + Math.Ceiling((Convert.ToDecimal(growStats[keys.Name][1]) + Convert.ToDecimal(level - 1) * Convert.ToDecimal(growStats[keys.Name][0])) * Convert.ToDecimal(attribute[type][keys.Name]) * Convert.ToDecimal(stats[keys.Name]) * Convert.ToDecimal(growratio) / 100 / 100);
괄호 수정하였습니다. 혹은 위의 코드를 사용하여도 됩니다.